### PR TITLE
Update local fork with newer versions 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,10 +11,10 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION = 26
-def DEFAULT_BUILD_TOOLS_VERSION = "27.0.3"
-def DEFAULT_TARGET_SDK_VERSION  = 22
-def DEFAULT_MIN_SDK_VERSION     = 17
+def DEFAULT_COMPILE_SDK_VERSION = 31
+def DEFAULT_BUILD_TOOLS_VERSION = "31.0.0"
+def DEFAULT_TARGET_SDK_VERSION  = 31
+def DEFAULT_MIN_SDK_VERSION     = 24
 
 android {
   compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
@@ -45,7 +45,7 @@ repositories {
 }
 
 dependencies {
-    implementation ('org.jitsi.react:jitsi-meet-sdk:3.7.0') {
+    implementation ('org.jitsi.react:jitsi-meet-sdk:5.1.0') {
       transitive = true
     }
 }

--- a/android/src/main/java/com/reactnativejitsimeet/RNJitsiMeetModule.java
+++ b/android/src/main/java/com/reactnativejitsimeet/RNJitsiMeetModule.java
@@ -74,7 +74,7 @@ public class RNJitsiMeetModule extends ReactContextBaseJavaModule {
                         .setFeatureFlag("pip.enabled", meetFeatureFlags.hasKey("pipEnabled") ?meetFeatureFlags.getBoolean("pipEnabled") : true)
                         .setFeatureFlag("kick-out.enabled", meetFeatureFlags.hasKey("kickOutEnabled") ?meetFeatureFlags.getBoolean("kickOutEnabled") : true)
                         .setFeatureFlag("conference-timer.enabled", meetFeatureFlags.hasKey("conferenceTimerEnabled") ?meetFeatureFlags.getBoolean("conferenceTimerEnabled") : true)
-                        .setFeatureFlag("video-share.enabled", meetFeatureFlags.hasKey("videoShareButtonEnabled") ?meetFeatureFlags.getBoolean("videoShareButtonEnabled") : true)
+                        .setFeatureFlag("video-share.enabled", meetFeatureFlags.hasKey("videoShareEnabled") ?meetFeatureFlags.getBoolean("videoShareEnabled") : true)
                         .setFeatureFlag("recording.enabled", meetFeatureFlags.hasKey("recordingEnabled") ?meetFeatureFlags.getBoolean("recordingEnabled") : true)
                         .setFeatureFlag("reactions.enabled", meetFeatureFlags.hasKey("reactionsEnabled") ?meetFeatureFlags.getBoolean("reactionsEnabled") : true)
                         .setFeatureFlag("raise-hand.enabled", meetFeatureFlags.hasKey("raiseHandEnabled") ?meetFeatureFlags.getBoolean("raiseHandEnabled") : true)
@@ -82,6 +82,7 @@ public class RNJitsiMeetModule extends ReactContextBaseJavaModule {
                         .setFeatureFlag("toolbox.alwaysVisible", meetFeatureFlags.hasKey("toolboxAlwaysVisible") ?meetFeatureFlags.getBoolean("toolboxAlwaysVisible") : false)
                         .setFeatureFlag("toolbox.enabled", meetFeatureFlags.hasKey("toolboxEnabled") ?meetFeatureFlags.getBoolean("toolboxEnabled") : true)
                         .setFeatureFlag("welcomepage.enabled", meetFeatureFlags.hasKey("welcomePageEnabled") ?meetFeatureFlags.getBoolean("welcomePageEnabled") : false)
+                        .setFeatureFlag("prejoinpage.enabled", meetFeatureFlags.hasKey("prejoinPageEnabled") ?meetFeatureFlags.getBoolean("prejoinPageEnabled") : false)
                         .build();
                     mJitsiMeetViewReference.getJitsiMeetView().join(options);
                 }

--- a/ios/RNJitsiMeetViewManager.m
+++ b/ios/RNJitsiMeetViewManager.m
@@ -89,8 +89,8 @@ RCT_EXPORT_METHOD(
               [builder setFeatureFlag:@"kick-out.enabled" withBoolean:[[meetFeatureFlags objectForKey:@"kickOutEnabled"] boolValue]];
             if(meetFeatureFlags[@"conferenceTimerEnabled"] != NULL)
               [builder setFeatureFlag:@"conference-timer.enabled" withBoolean:[[meetFeatureFlags objectForKey:@"conferenceTimerEnabled"] boolValue]];
-            if(meetFeatureFlags[@"meetingPasswordEnabled"] != NULL)
-              [builder setFeatureFlag:@"video-share.enabled" withBoolean:[[meetFeatureFlags objectForKey:@"meetingPasswordEnabled"] boolValue]];
+            if(meetFeatureFlags[@"videoShareEnabled"] != NULL)
+              [builder setFeatureFlag:@"video-share.enabled" withBoolean:[[meetFeatureFlags objectForKey:@"videoShareEnabled"] boolValue]];
             if(meetFeatureFlags[@"meetingPasswordEnabled"] != NULL)
               [builder setFeatureFlag:@"meeting-password.enabled" withBoolean:[[meetFeatureFlags objectForKey:@"meetingPasswordEnabled"] boolValue]];
             if(meetFeatureFlags[@"pipEnabled"] != NULL)
@@ -99,6 +99,8 @@ RCT_EXPORT_METHOD(
               [builder setFeatureFlag:@"tile-view.enabled" withBoolean:[[meetFeatureFlags objectForKey:@"tileViewEnabled"] boolValue]];
             if(meetFeatureFlags[@"welcomePageEnabled"] != NULL)
               [builder setFeatureFlag:@"welcomepage.enabled" withBoolean:[[meetFeatureFlags objectForKey:@"welcomePageEnabled"] boolValue]];
+            if(meetFeatureFlags[@"prejoinPageEnabled"] != NULL)
+              [builder setFeatureFlag:@"prejoinpage.enabled" withBoolean:[[meetFeatureFlags objectForKey:@"prejoinPageEnabled"] boolValue]];
 
             builder.userInfo = _userInfo;
         }];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-jitsi-meet",
   "description": "Jitsi Meet SDK wrapper for React Native.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "Sébastien Krafft",
     "email": "skrafft@gmail.com"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-jitsi-meet",
   "description": "Jitsi Meet SDK wrapper for React Native.",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": {
     "name": "Sébastien Krafft",
     "email": "skrafft@gmail.com"

--- a/react-native-jitsi-meet.podspec
+++ b/react-native-jitsi-meet.podspec
@@ -10,11 +10,11 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platform     = :ios, "11.0"
+  s.platform     = :ios, "12.0"
 
   s.source       = { :git => "https://github.com/skrafft/react-native-jitsi-meet.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'JitsiMeetSDK', '3.10.2'
+  s.dependency 'JitsiMeetSDK', '6.2.2'
 end

--- a/react-native-jitsi-meet.podspec
+++ b/react-native-jitsi-meet.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'JitsiMeetSDK', '6.2.2'
+  s.dependency 'JitsiMeetSDK', '5.1.1'
 end


### PR DESCRIPTION
Due to the react native upgrade, which fixed the Android build, a newer version is needed for the iOS build to run flawlessly. This version is included in the latest master release from skrafft (Jitsi meet sdk >5.0.2).

It has been tested and ran on both devices with no issues.